### PR TITLE
Clean hash stripping

### DIFF
--- a/lib/navigo.js
+++ b/lib/navigo.js
@@ -250,6 +250,7 @@ Navigo.prototype = {
     var url = (current || this._cLoc()).replace(this._getRoot(), '');
 
     if (this._useHash) {
+      url = url.replace(this._getRoot().replace(this._hash, ''), '');
       url = url.replace(new RegExp('^\/' + this._hash), '/');
     }
 


### PR DESCRIPTION
 - do not resolve hash anchors (#) if hash-bang (#!) is defined as hash